### PR TITLE
Support WP's new asset file format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,19 @@ class ExposePackageDependenciesWebpackPlugin {
 					const packageDepsFilename = packageData.main.replace( /\.js$/i, extension );
 					const packageDeps = require( `${packageName}/${packageDepsFilename}` );
 
-					if ( ! Array.isArray( packageDeps ) ) {
-						return;
+          let dependencies = [];
+
+          if ( Array.isArray( packageDeps.dependencies || null ) ) {
+            dependencies = packageDeps.dependencies;
+          }
+
+					if ( Array.isArray( packageDeps ) ) {
+            dependencies = packageDeps;
 					}
+
+          if ( dependencies.length < 1 ) {
+            return;
+          }
 
 					// Merge the package dependencies into the consumer's dependencies.
 					deps = union( deps, packageDeps );

--- a/src/index.js
+++ b/src/index.js
@@ -1,82 +1,92 @@
 const { RawSource } = require( 'webpack-sources' );
-const { union } = require( 'lodash' );
+const { find, findKey, get, union } = require( 'lodash' );
 
 class ExposePackageDependenciesWebpackPlugin {
-	constructor( options ) {
-		this.options = options;
-	}
+  constructor( options ) {
+    this.options = options;
+  }
 
-	apply( compiler ) {
-		const { output } = compiler.options;
-		const { filename: outputFilename } = output;
+  apply( compiler ) {
+    const { output } = compiler.options;
+    const { filename: outputFilename } = output;
 
-		compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
-			// Iterate on the entrypoints (there is probably just one).
-			for ( const [ entrypointName, entrypoint ] of compilation.entrypoints.entries() ) {
-				const [ filename, query ] = entrypointName.split( '?', 2 );
+    compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
+      // Iterate on the entrypoints (there is probably just one).
+      for ( const [ entrypointName, entrypoint ] of compilation.entrypoints.entries() ) {
+        const [ filename, query ] = entrypointName.split( '?', 2 );
 
-				// Get the name of the dependency file.
-				const buildFilename = compilation.getPath( outputFilename, {
-					chunk: entrypoint.getRuntimeChunk(),
-					filename,
-					query,
-					basename: basename( filename ),
+        // Get the name of the dependency file.
+        const buildFilename = compilation.getPath( outputFilename, {
+          chunk: entrypoint.getRuntimeChunk(),
+          filename,
+          query,
+          basename: basename( filename ),
         } );
 
-        // We have to jump through some hoops here because WordPress changed the dependency file format.
-        const oldAssetFilename = buildFilename.replace( /\.js$/i, '.deps.json' );
-        const newAssetFilename = buildFilename.replace( /\.js$/i, '.asset.json' );
+        const extensions = [
+          '.asset.json',
+          '.deps.json',
+        ];
 
-        const isNew = compilation.assets[ oldAssetFilename ] || null;
-        const isOld = compiliation.assets[ newAssetFilename ] || null;
+        // Check if the build file has a matching asset file. If so, get the file.
+        const assetFiles = extensions.map( ( ext ) => buildFilename.replace( /\.js$/i, ext ) );
+        const assetFileName = findKey( compilation.assets, ( value, key ) => assetFiles.includes( key ) );
+        const asset = get( compilation.assets, assetFileName, null );
 
-				if ( isNew === null && isOld === null ) {
-					return;
+        if ( asset === null ) {
+          return;
         }
 
-        const extension = ( isNew !== null ) ? '.asset.json' : '.deps.json';
+        // Parse the existing source file, so it can be modified.
+        let deps = JSON.parse( asset.source() );
 
-				// Parse the existing source file, so it can be modified.
-				let deps = JSON.parse( asset.source() );
+        // Loop over the specified packages.
+        this.options.packages.forEach( ( packageName ) => {
+          let packageDependencies = null;
 
-				// Loop over the specified packages.
-				this.options.packages.forEach( ( packageName ) => {
-					// Get the package's deps.json file.
-					const packageData = require( packageName + '/package.json' );
-					const packageDepsFilename = packageData.main.replace( /\.js$/i, extension );
-					const packageDeps = require( `${packageName}/${packageDepsFilename}` );
+          try {
+            // Get the list of possible asset files.
+            const packageData = require( packageName + '/package.json' );
+            const packageAssetFiles = extensions.map( ( ext ) => packageData.main.replace( /\.js$/i, ext ) );
 
-          let dependencies = [];
+            // Attempt to get the dependencies from each possible asset file.
+            const assetFiles = packageAssetFiles.map( ( filename ) => {
+              try {
+                const assetFile = require( `${packageName}/${filename}` );
 
-          if ( Array.isArray( packageDeps.dependencies || null ) ) {
-            dependencies = packageDeps.dependencies;
-          }
+                return 'dependencies' in assetFile ? assetFile.dependencies : assetFile;
+              } catch ( e ) {
+                return false;
+              }
+            } );
 
-					if ( Array.isArray( packageDeps ) ) {
-            dependencies = packageDeps;
-					}
-
-          if ( dependencies.length < 1 ) {
+            // If we were able to find any dependencies, get them.
+            packageDependencies = find( assetFiles, ( item ) => !! item.length ) || null;
+          } catch ( e ) {
             return;
           }
 
-					// Merge the package dependencies into the consumer's dependencies.
-					deps = union( deps, packageDeps );
-				} );
+          if ( packageDependencies === null ) {
+            return;
+          }
 
-				// Output the result back to the dependency file.
-				compilation.assets[ depsFilename ] = new RawSource( JSON.stringify( deps ) );
-			}
-		} );
-	}
+          // Merge the package's dependencies into the consumer's dependencies.
+          deps = union( deps, packageDependencies );
+        } );
+
+        // Output the result back to the dependency file.
+        compilation.assets[ assetFileName ] = new RawSource( JSON.stringify( deps ) );
+      }
+    } );
+  }
 }
 
 function basename( name ) {
-	if ( ! name.includes( '/' ) ) {
-		return name;
-	}
+  if ( ! name.includes( '/' ) ) {
+    return name;
+  }
 
-	return name.substr( name.lastIndexOf( '/' ) + 1 );
+  return name.substr( name.lastIndexOf( '/' ) + 1 );
 }
 
 module.exports = ExposePackageDependenciesWebpackPlugin;


### PR DESCRIPTION
WordPress core changed the asset file extension from `.deps.json` to `.asset.json`. This PR attempts to change the behavior of this plugin to support both old and new formats, preferring the new format when available.