### PR TITLE
Fix writing to asset files with the new format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,14 @@ class ExposePackageDependenciesWebpackPlugin {
           }
 
           // Merge the package's dependencies into the consumer's dependencies.
-          deps = union( deps, packageDependencies );
+          if ( 'dependencies' in deps ) {
+            deps.dependencies = union( deps.dependencies, packageDependencies ).sort();
+          }
+
+          // Fallback for legacy dependency files.
+          if ( ! 'dependencies' in deps ) {
+            deps = union( deps, packageDependencies ).sort();
+          }
         } );
 
         // Output the result back to the dependency file.


### PR DESCRIPTION
Ensures the dependencies array is written to `asset.dependencies` if it exists.